### PR TITLE
Orfm refactor

### DIFF
--- a/graftm/hmmer.py
+++ b/graftm/hmmer.py
@@ -479,28 +479,20 @@ class Hmmer:
         # recieves reads, and returns hits
         start = timeit.default_timer() # Start search timer
         
-        orfm = OrfM({'min_orf_length': args.min_orf_length,
-                     'restrict_read_length': args.restrict_read_length})
+        orfm = OrfM(min_orf_length=args.min_orf_length,
+                    restrict_read_length=args.restrict_read_length)
         
-        # Searching raw reads with HMM
-        if args.accept_all_reads:
-            run_stats, hit_readnames = self.accept_all_reads(raw_reads,
-                                                             input_file_format,
-                                                             args.input_sequence_type,
-                                                             orfm)
-        else:
-            hit_table = self.hmmsearch(files.hmmsearch_output_path(base),
-                                       raw_reads,
-                                       input_file_format,
-                                       args.input_sequence_type,
-                                       args.threads,
-                                       args.eval,
-                                       args.min_orf_length,
-                                       args.restrict_read_length)
-            # Processing the output table to give you the readnames of the hits
-            run_stats, hit_readnames = self.csv_to_titles(files.readnames_output_path(base),
-                                                          hit_table,
-                                                          run_stats)
+        hit_table = self.hmmsearch(files.hmmsearch_output_path(base),
+                                   raw_reads,
+                                   input_file_format,
+                                   args.input_sequence_type,
+                                   args.threads,
+                                   args.eval,
+                                   orfm)
+        # Processing the output table to give you the readnames of the hits
+        run_stats, hit_readnames = self.csv_to_titles(files.readnames_output_path(base),
+                                                      hit_table,
+                                                      run_stats)
 
         if not hit_readnames:
             return False, run_stats
@@ -526,8 +518,7 @@ class Hmmer:
                                          files.orf_output_path(base),
                                          files.orf_hmmsearch_output_path(base),
                                          files.orf_titles_output_path(base),
-                                         args.min_orf_length,
-                                         args.restrict_read_length,
+                                         orfm,
                                          files.orf_fasta_output_path(base))
         elif args.input_sequence_type == 'protein':
             hit_orfs = hit_reads

--- a/graftm/orfm.py
+++ b/graftm/orfm.py
@@ -1,0 +1,21 @@
+class OrfM:
+    def __init__(self, **kwargs):
+        self.min_orf_length = kwargs.pop('min_orf_length',None)
+        self.restrict_read_length = kwargs.pop('restrict_read_length',None)
+        if len(kwargs) > 0:
+            raise Exception("Unexpected arguments detected: %s" % kwargs)
+        self.min_orf_length = 96
+        
+    def command_line(self):
+        '''Return a string to run OrfM with, assuming sequences are incoming on
+        stdin and printed to stdout'''
+        
+        if self.min_orf_length:
+            orfm_arg_l = " -m %d" % self.min_orf_length
+        else:
+            orfm_arg_l = ''
+        
+        if self.restrict_read_length:
+            orfm_arg_l = " -l %d" % self.restrict_read_length
+            
+        return 'orfm %s ' % orfm_arg_l


### PR DESCRIPTION
Just cleaning up the code a bit. OrfM is now its own class (with a `command_line` method) which gets instantiated once and parameters set, so that the entire set of OrfM parameters need not be passed around to several functions, instead only set once at the beginning of the pipeline.