### PR TITLE
only guess sequence type with the first 300 chars, and require >10% amino acids to call it a protein

### DIFF
--- a/test/test_housekeeping.py
+++ b/test/test_housekeeping.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+#=======================================================================
+# Authors: Ben Woodcroft, Joel Boyd
+#
+# Unit tests.
+#
+# Copyright
+#
+# This is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License.
+# If not, see <http://www.gnu.org/licenses/>.
+#=======================================================================
+
+import unittest
+import os
+import sys
+
+sys.path = [os.path.join(os.path.dirname(os.path.realpath(__file__)),'..')]+sys.path
+from graftm.housekeeping import HouseKeeping
+
+class Tests(unittest.TestCase):
+    def test__guess_sequence_type(self):
+        hk = HouseKeeping()
+        self.assertEqual('protein', hk._guess_sequence_type_from_string('P'*10))
+        self.assertEqual('protein', hk._guess_sequence_type_from_string('P'*10+'T'*89))
+        self.assertEqual('nucleotide', hk._guess_sequence_type_from_string('P'*10+'T'*90))
+        self.assertEqual('nucleotide', hk._guess_sequence_type_from_string('A'*300+'E'*999)) #only look at the first 300bp
+        
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Came across a genome file where the entire genome was on the second line of the file, and there was 2 non-ATGCNU characters in the 4 Mbp or so, so it was calling it a protein sequence.