### PR TITLE
standardise the bootstrap HMM output file

### DIFF
--- a/graftm/bootstrapper.py
+++ b/graftm/bootstrapper.py
@@ -52,7 +52,6 @@ class Bootstrapper:
         True if genes were recovered, else False'''
         
         hmmer = Hmmer(self.search_hmm_files)
-        print self.search_hmm_files
         
         with tempfile.NamedTemporaryFile(prefix='graftm_bootstrap_orfs') as orfs:
             logging.info("Finding bootstrap hits in provided contigs..")

--- a/graftm/graftm_output_paths.py
+++ b/graftm/graftm_output_paths.py
@@ -86,6 +86,9 @@ class GraftMFiles:
     
     def combined_summary_table_output_path(self):
         return os.path.join(self.outdir, "combined_count_table.txt")
+    
+    def bootstrap_hmm_path(self):
+        return os.path.join(self.outdir, "bootstrap.hmm")
       
     def base(self, out_path):
         return os.path.join(self.outdir, out_path, "%s" % self.basename)

--- a/graftm/run.py
+++ b/graftm/run.py
@@ -264,7 +264,7 @@ class Run:
                 if self.args.type == PIPELINE_AA:
                     logging.debug("Running protein pipeline")
                     if self.args.bootstrap_contigs:
-                        new_hmm = tempfile.NamedTemporaryFile(prefix='graftm_bootstrap',suffix='.hmm')
+                        new_hmm = self.gmf.bootstrap_hmm_path()
                         if self.args.graftm_package:
                             pkg = GraftMPackage.acquire(self.args.graftm_package)
                         else:
@@ -278,8 +278,8 @@ class Run:
                             graftm_package = pkg)
                         if boots.generate_hmm_from_contigs(
                                                  self.args.bootstrap_contigs,
-                                                 new_hmm.name):
-                            self.h.search_hmm.append(new_hmm.name)
+                                                 new_hmm):
+                            self.h.search_hmm.append(new_hmm)
 
                     search_time, result = self.h.aa_db_search(
                                                               self.gmf,

--- a/test/test_graft.py
+++ b/test/test_graft.py
@@ -892,6 +892,11 @@ TAGTCTCGGGTCTACTACGAATAGCAAGTCTACCTCAAGG
                 subprocess.check_output(cmd, shell=True)
                 self.assertEqual(testing_read, open(os.path.join(tmp, sample_name, '%s_hits.fa' % sample_name)).read())
 
+                bootstrap_hmm_path = os.path.join(tmp, 'bootstrap.hmm')
+                self.assertTrue(os.path.isfile(bootstrap_hmm_path))
+                self.assertEqual('HMMER3/f [3.1b2 | February 2015]\n',
+                                 open(bootstrap_hmm_path).readlines()[0])
+
 
 
         


### PR DESCRIPTION
This is just so the bootstrap HMM is now `bootstrap.hmm` in the base of the output directory.