### PR TITLE
fix graftM bootstrap regression, add test

### DIFF
--- a/graftm/bootstrapper.py
+++ b/graftm/bootstrapper.py
@@ -1,9 +1,7 @@
 import logging
 import tempfile
 import shutil
-import os
 import extern
-import json
 
 from graftm.hmmer import Hmmer
 from graftm.unpack_sequences import UnpackRawReads
@@ -39,8 +37,10 @@ class Bootstrapper:
         if graftm_package:
             self.diamond_database = graftm_package.diamond_database_path()
             self.unaligned_sequence_database = graftm_package.unaligned_sequence_database_path()
+            if self.search_hmm_files is None:
+                self.search_hmm_files = []
             for h in graftm_package.search_hmm_paths():
-                if h not in self.search_hmm_files: 
+                if h not in self.search_hmm_files:
                     self.search_hmm_files.append(h)
             if self.maximum_range is None:
                 self.maximum_range = graftm_package.maximum_range()

--- a/graftm/run.py
+++ b/graftm/run.py
@@ -552,5 +552,7 @@ class Run:
                 evalue = args.evalue,
                 min_orf_length = args.min_orf_length,
                 graftm_package = pkg)
-            strapper.generate_bootstrap_database_from_contigs(args.contigs, args.output_hmm)
+            strapper.generate_bootstrap_database_from_contigs(args.contigs,
+                                                              args.output_hmm,
+                                                              search_method=Bootstrapper.HMM_SEARCH_METHOD)
 

--- a/test/test_bootstrapper.py
+++ b/test/test_bootstrapper.py
@@ -30,10 +30,12 @@ import sys
 import tempfile
 import subprocess
 import logging
+import extern
 
 sys.path = [os.path.join(os.path.dirname(os.path.realpath(__file__)),'..')]+sys.path
 from graftm.bootstrapper import Bootstrapper
 
+path_to_script = os.path.join(os.path.dirname(os.path.realpath(__file__)),'..','bin','graftM')
 path_to_data = os.path.join(os.path.dirname(os.path.realpath(__file__)),'data')
 
 class Tests(unittest.TestCase):
@@ -83,7 +85,18 @@ class Tests(unittest.TestCase):
                                 [contigs.name],
                                 tf.name,
                                 "hmmsearch"))
-
+                
+    def test_bootstrap_executable(self):
+        with tempfile.NamedTemporaryFile() as tf:
+            cmd = '%s bootstrap --verbosity 5 --contigs %s --output_hmm %s --search_hmm_files %s' % (path_to_script,
+                                                                                              os.path.join(path_to_data,'bootstrapper','contigs.fna'),
+                                                                                              tf.name,
+                                                                                              os.path.join(path_to_data,'bootstrapper','DNGNGWU00001.hmm'))
+            extern.run(cmd)
+            self.assertEqual("HMMER3/f [3.1b2 | February 2015]\n",
+                             subprocess.check_output("head -n1 %s" % tf.name,
+                                                     shell=True))
+            self.assertEqual('NSEQ  2\n', open(tf.name).readlines()[10])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Thanks to @caity-s for reporting this one. I realise now that `graftM bootstrap` cannot handle diamond output, only HMM output, but I'll leave that for another time.