### PR TITLE
import_error_patch

### DIFF
--- a/graftm/housekeeping.py
+++ b/graftm/housekeeping.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import logging
 from graftm.graftm_package import GraftMPackage
-from graftm.prerequisite_checker import PrerequisiteChecker
 import inspect
 
 PIPELINE_AA = "P"
@@ -143,7 +142,7 @@ following extensions: %s" % ' '.join(valid_extensions.keys()))
         return max_length
 
     def set_attributes(self, args):
-        
+
 
         # Read graftM package and assign HMM and refpkg file
         if args.graftm_package:


### PR DESCRIPTION
Left a PrerequisiteChecker import in housekeeping.py. This class has been deprecated, causing an import error when master was cloned into a clean dir. 