### PR TITLE
add shell script to check for untracked .py files, update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .project
 .pydevproject
+virtualenv
+build

--- a/check-for-untracked-files.sh
+++ b/check-for-untracked-files.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+#
+# A hook script to verify that a push is not done with untracked source file
+#
+# To use it, either symlink this script to $your-git-clone/.git/hooks/pre-push
+# or include it in your existing pre-push script.
+#
+
+# Perl-style regular expression which limits the files we interpret as source files.
+# The default pattern here excludes CMakeLists.txt files and any .h/.cpp/.cmake files.
+# Extend/adapt this to your needs. Alternatively, set the pattern in your repo via:
+#     git config hooks.prepush.sourcepattern "$your-pattern"
+pattern=$(git config --get hooks.prepush.sourcepattern)
+if [ -z "$pattern" ]; then
+  pattern="\.py$"
+fi
+
+echo "Checking for untracked files that match the pattern '$pattern'"
+files=$(git status -u --porcelain --no-column | sed "s/^?? //" | grep -P "$pattern")
+if [ -z "$files" ]; then
+  exit 0
+fi
+
+echo
+echo "ERROR: Preventing push with untracked source files:"
+echo
+echo "$files" | sed "s/^/    /"
+echo
+echo "Either include these files in your commits, add them to .gitignore"
+echo "or stash them with git stash -u."
+echo
+exit 1


### PR DESCRIPTION
Hey, just learned about git hooks, pretty nice stuff. After doing the following it won't let you commit if there are any untracked .py files in your graftm git clone. Actually contrary to the name of the branch it checks upon commit, not upon push, but eh.

```
cd .git/hooks
ln -s ../../check-for-untracked-files.sh pre-commit
```
Then when you commit you see the extra check in action
```
$ git commit ...
Checking for untracked files that match the pattern '\.py$'
[pre-push-hook c60cb6b] add shell script to check for untracked .py files, update .gitignore
 Date: Mon Jan 11 11:02:46 2016 +1000
 2 files changed, 35 insertions(+)
 create mode 100755 check-for-untracked-files.sh
```