### PR TITLE
geronimp-slash_error patch

### DIFF
--- a/graftm/clusterer.py
+++ b/graftm/clusterer.py
@@ -3,6 +3,7 @@ from graftm.sequence_io import SequenceIO
 from graftm.orfm import OrfM
 import logging
 import os
+import re
 
 class Clusterer:
 
@@ -10,7 +11,7 @@ class Clusterer:
         self.clust = Deduplicator()
         self.seqio = SequenceIO()
         self.seq_library = {}
-
+        self.slash_ending_regex = re.compile('.*/[12]$')
         self.orfm_regex = OrfM.regular_expression()
 
 
@@ -47,7 +48,9 @@ class Clusterer:
                 placed_alignment_base = placed_alignment_file.replace('_clustered.fa', '')
             output_annotations[placed_alignment_base] = {}
             for rep_read_name, rep_read_taxonomy in cluster_classifications.iteritems():
-
+                slashendingregex = self.slash_ending_regex.match(rep_read_name)
+                if slashendingregex:
+                    rep_read_name=rep_read_name[:-2]
                 if reverse_pipe:
                     orfm_regex = OrfM.regular_expression()
                     clusters={(orfm_regex.match(key).groups(0)[0] if orfm_regex.match(key) else key): item for key, item in clusters.iteritems()}
@@ -68,12 +71,14 @@ class Clusterer:
             list of strings, each a path to input fasta files to be clustered.
         reverse_pipe : bool
             True/False, whether the reverse reads pipeline is being followed.
+
         Returns
         -------
         output_fasta_list : list
             list of strings, each a path to the output fasta file to which
             clusters were written to.
         '''
+        
         output_fasta_list = []
         for input_fasta in input_fasta_list:
             output_path  = input_fasta.replace('_hits.aln.fa', '_clustered.fa')
@@ -91,7 +96,11 @@ class Clusterer:
                                         output_path
                                         ) # Choose the first sequence to write to file as representative (all the same anyway)
             for cluster in clusters:
-                cluster_dict[cluster[0].name]=cluster # assign the cluster to the dictionary
+                if self.slash_ending_regex.match(cluster[0].name):
+                    name = cluster[0].name[:-2]
+                else:
+                    name = cluster[0].name                    
+                cluster_dict[name]=cluster # assign the cluster to the dictionary
             self.seq_library[output_path]= cluster_dict
 
             output_fasta_list.append(output_path)

--- a/graftm/hmmer.py
+++ b/graftm/hmmer.py
@@ -5,6 +5,7 @@ import itertools
 import logging
 import tempfile
 import subprocess
+import re
 
 from Bio import SeqIO
 from collections import OrderedDict
@@ -229,37 +230,39 @@ class Hmmer:
         -------
         Nothing - output files are known.
         '''
-
+        slash_ending_regex = re.compile('.*/[12]$')
         orfm_regex = OrfM.regular_expression()
-        def remove_orfm_end(records):
+        
+        def clean_read_headers(records):
 
             new_dict = {}
 
             for key, record in records.iteritems():
+                slashregex = slash_ending_regex.match(key)
+                if slashregex:
+                    key = key[:-2]
+                
                 orfmregex = orfm_regex.match(key)
                 if orfmregex:
-                    new_dict[orfmregex.groups(0)[0]] = record
-                else:
-                    new_dict[key] = record
+                    key = orfmregex.groups(0)[0] 
+                    
+                new_dict[key] = record
+            
             return new_dict
 
 
         for idx, (forward_path, reverse_path) in enumerate(zip(forward_aln_list, reverse_aln_list)):
+            
             output_path = outputs[idx]
             logging.info('Merging pair %s, %s' % (os.path.basename(forward_path), os.path.basename(reverse_path)))
-            forward_reads = SeqIO.parse(forward_path, 'fasta')
-            reverse_reads = remove_orfm_end(SeqIO.to_dict(SeqIO.parse(reverse_path, 'fasta')))
-
+            forward_reads = clean_read_headers(SeqIO.to_dict(SeqIO.parse(forward_path, 'fasta')))
+            reverse_reads = clean_read_headers(SeqIO.to_dict(SeqIO.parse(reverse_path, 'fasta')))
+            
             with open(output_path, 'w') as out:
-                for forward_record in forward_reads:
-                    regex_match = orfm_regex.match(forward_record.id)
-                    if regex_match:
-                        id = regex_match.groups(0)[0]
-                    else:
-                        id = forward_record.id
+                for key, forward_record in forward_reads.iteritems():
                     forward_sequence = str(forward_record.seq)
                     try:
-                        reverse_sequence = str(reverse_reads[id].seq)
+                        reverse_sequence = str(reverse_reads[key].seq)
                         new_seq = ''
                         if len(forward_sequence) == len(reverse_sequence):
                             for f, r in zip(forward_sequence, reverse_sequence):
@@ -274,16 +277,17 @@ class Hmmer:
                                         new_seq += f
                                 else:
                                     new_seq += '-'
+                        
                         else:
                             logging.error('Alignments do not match')
                             raise Exception('Merging alignments failed: Alignments do not match')
                         out.write('>%s\n' % forward_record.id)
                         out.write('%s\n' % (new_seq))
-                        del reverse_reads[id]
+                        del reverse_reads[key]
                     except:
-
                         out.write('>%s\n' % forward_record.id)
                         out.write('%s\n' % (forward_sequence))
+                
                 for record_id, record in reverse_reads.iteritems():
                     out.write('>%s\n' % record_id)
                     out.write('%s\n' % (str(record.seq)))

--- a/graftm/run.py
+++ b/graftm/run.py
@@ -232,7 +232,7 @@ class Run:
        
         # If merge reads is specified, check that there are reverse reads to merge with
         if self.args.merge_reads and not hasattr(self.args, 'reverse'):
-            logging.error("--merge requires --reverse to be specified")
+            logging.error("--merge_reads requires --reverse to be specified")
             exit(1)
 
         # Set the output directory if not specified and create that directory
@@ -410,7 +410,6 @@ class Run:
             self.h.merge_forev_aln(seqs_list[0::2], seqs_list[1::2], merged_output)
             seqs_list=merged_output
             REVERSE_PIPE = False
-
         elif REVERSE_PIPE:
             base_list=base_list[0::2]
 

--- a/graftm/unpack_sequences.py
+++ b/graftm/unpack_sequences.py
@@ -1,9 +1,11 @@
 import logging
 import subprocess
-from signal import signal, SIGPIPE, SIG_DFL
 import os
 import itertools
+import re
 from string import lower
+from db_search_results import DBSearchResult
+from signal import signal, SIGPIPE, SIG_DFL
 
 class UnpackRawReads:
     class UnexpectedFileFormatException(Exception): pass

--- a/test/test_graft.py
+++ b/test/test_graft.py
@@ -1195,6 +1195,55 @@ CGGGGTATCTAATCCCGTTCGCTCCCCTAGCTTTCGTGCCTCAGCGTCAGAAAAGACCCAGTGAGCCGCTTTCGCCCCCG
 +
 \a_ccO_ceceeehdgaffZ^degfggfdefggib^ef^cecRafeefgdZecf_dd`gbcZ___b]aUZaa`aa__aaX__TT[]_bY]Y`]RG]`b_b
 '''
+        expected_aln = """>FCC0WM1ACXX:2:2208:12709:74426#GTCCAGAA/1_0 FCC0WM1ACXX:2:2208:12709:74426#GTCCAGAA/1
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+-----------------------ACACTGCCCAGACACCTACGGGTGGCTGCAGTCGAGG
+ATCTTCGGCAATGGGCGAAAGCCTGACCGAGCGACGCCGCGTGTGGGATGAAGGCCCTCG
+GG----------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+---------------------------------
+>FCC0WM1ACXX:2:2208:12709:74426#GTCCAGAA/2_1 FCC0WM1ACXX:2:2208:12709:74426#GTCCAGAA/2
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+-----TTGATATCCTAAGGAACACCGGGGGCGAAAGCGGCTCACTGGGTCTTCTGACGCT
+GAGGCACGAAAGCTAGGGGAGCGAACGGGATTAGATACCCC-------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+---------------------------------""".split('\n')
+
         with tempfile.NamedTemporaryFile(suffix='.fq') as fwd_f:
             fwd_f.write(fwd)
             fwd_f.flush()
@@ -1209,9 +1258,71 @@ CGGGGTATCTAATCCCGTTCGCTCCCCTAGCTTTCGTGCCTCAGCGTCAGAAAAGACCCAGTGAGCCGCTTTCGCCCCCG
                                                                                                                      tmp,
                                                                                                                      os.path.join(path_to_data,'61_otus.gpkg'))
                     extern.run(cmd)
-                    raise Exception("At least it runs, but nt sure what is expected for this test. Before it didn't even run")
-    
-        
+                    expected = [['#ID',os.path.basename(fwd_f.name)[:-3],'ConsensusLineage'],
+                                ['1','1','Root; k__Bacteria']]
+                    for idx, line in enumerate(open(os.path.join(tmp,'combined_count_table.txt')).readlines()):
+                        self.assertEqual(expected[idx], line.strip().split('\t'))
+                    for idx, line in enumerate(open(os.path.join(tmp,'combined_alignment.aln.fa')).readlines()):
+                        self.assertEqual(expected_aln[idx], line.strip())
+
+    def test_forward_and_reverse_slash_type_fastq_merge_reads(self):
+        fwd = '''@FCC0WM1ACXX:2:2208:12709:74426#GTCCAGAA/1
+ACACTGCCCAGACACCTACGGGTGGCTGCAGTCGAGGATCTTCGGCAATGGGCGAAAGCCTGACCGAGCGACGCCGCGTGTGGGATGAAGGCCCTCGGGT
++
+^^_cccacgeecafgfghhhhheYea_c^efaff`eggfhhhhf]`_d]]X^aa\]^Y^a`[^bbaZaaaa]]a]_[]HTX`[[[_[]`_][`^^`]__a
+'''
+        rev = '''@FCC0WM1ACXX:2:2208:12709:74426#GTCCAGAA/2
+CGGGGTATCTAATCCCGTTCGCTCCCCTAGCTTTCGTGCCTCAGCGTCAGAAAAGACCCAGTGAGCCGCTTTCGCCCCCGGTGTTCCTTAGGATATCAAC
++
+\a_ccO_ceceeehdgaffZ^degfggfdefggib^ef^cecRafeefgdZecf_dd`gbcZ___b]aUZaa`aa__aaX__TT[]_bY]Y`]RG]`b_b
+'''
+        expected_aln = """>FCC0WM1ACXX:2:2208:12709:74426#GTCCAGAA/1_0 FCC0WM1ACXX:2:2208:12709:74426#GTCCAGAA/1
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+-----------------------ACACTGCCCAGACACCTACGGGTGGCTGCAGTCGAGG
+ATCTTCGGCAATGGGCGAAAGCCTGACCGAGCGACGCCGCGTGTGGGATGAAGGCCCTCG
+GG----------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+-----TTGATATCCTAAGGAACACCGGGGGCGAAAGCGGCTCACTGGGTCTTCTGACGCT
+GAGGCACGAAAGCTAGGGGAGCGAACGGGATTAGATACCCC-------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+------------------------------------------------------------
+---------------------------------""".split('\n')
+
+        with tempfile.NamedTemporaryFile(suffix='.fq') as fwd_f:
+            fwd_f.write(fwd)
+            fwd_f.flush()
+            with tempfile.NamedTemporaryFile(suffix='.fq') as rev_f:
+                rev_f.write(rev)
+                rev_f.flush()
+
+                with tempdir.TempDir() as tmp:
+                    cmd = '%s graft --merge_reads --verbosity 5 --forward %s --reverse %s --output_directory %s --force --graftm_package %s' % (path_to_script,
+                                                                                                                     fwd_f.name,
+                                                                                                                     rev_f.name,
+                                                                                                                     tmp,
+                                                                                                                     os.path.join(path_to_data,'61_otus.gpkg'))
+                    extern.run(cmd)
+                    expected = [['#ID',os.path.basename(fwd_f.name)[:-3],'ConsensusLineage'],
+                                ['1','1','Root; k__Bacteria']]
+                    for idx, line in enumerate(open(os.path.join(tmp,'combined_count_table.txt')).readlines()):
+                        self.assertEqual(expected[idx], line.strip().split('\t'))
+                    for idx, line in enumerate(open(os.path.join(tmp,'combined_alignment.aln.fa')).readlines()):
+                        self.assertEqual(expected_aln[idx], line.strip())
+
+
     def test_filter_minimum(self):
         testing = '''>NS500333:6:H1124BGXX:1:23310:10768:12778 1:N:0:GATCAG
 CGGGAGGAACACCAGTGGCGAAGGCGGCTTCCTGGCCTGTTCTTGACGCTGAGGCGCGAA

--- a/test/test_hmmer.py
+++ b/test/test_hmmer.py
@@ -55,18 +55,18 @@ class Tests(unittest.TestCase):
 -------CGTATGCAACCTACCTT---------------------------------------
 >complete_overlap_mismatch
 -------CGTTTGCAAGCTACCTT---------------------------------------'''
-        expected_aln='''>no_overlap
--------CGTATGCAACCTACCTT---------------CGTATGCAACCTACCTT-------
->overlap_all_match
--------CGTATGCAACCTACCTTCAACCTACCTT----------------------------
->overlap_mismatch_in_reverse
--------CGTATGCAACCTACCTTCAACCTACCTT----------------------------
->overlap_mismatch_in_forward
--------CGTATGCAACCTTCCTTCAACCTACCTT----------------------------
->complete_overlap_all_match
+        expected_aln='''>complete_overlap_all_match
 -------CGTATGCAACCTACCTT---------------------------------------
 >complete_overlap_mismatch
--------CGTATGCATCCTACCTT---------------------------------------'''.split()
+-------CGTATGCATCCTACCTT---------------------------------------
+>overlap_all_match
+-------CGTATGCAACCTACCTTCAACCTACCTT----------------------------
+>no_overlap
+-------CGTATGCAACCTACCTT---------------CGTATGCAACCTACCTT-------
+>overlap_mismatch_in_forward
+-------CGTATGCAACCTTCCTTCAACCTACCTT----------------------------
+>overlap_mismatch_in_reverse
+-------CGTATGCAACCTACCTTCAACCTACCTT----------------------------'''.split()
         with tempfile.NamedTemporaryFile(suffix='_forward.fa') as forward_file:
             with tempfile.NamedTemporaryFile(suffix='_reverse.fa') as reverse_file:
                 with tempfile.NamedTemporaryFile(suffix='.fa') as output_file:


### PR DESCRIPTION
Patch to the /2 /1 ending error. I also added another test which tests for another bug I found when working with /2 /1 endings too. Some changes to test_hmmer.py that accommodate for the different order which the read merging outputs reads now - no effect here on output of graftM graft.
