### PR TITLE
decorate: Use correct variable so error messages compile correctly.

### DIFF
--- a/graftm/tree_decorator.py
+++ b/graftm/tree_decorator.py
@@ -133,7 +133,7 @@ is the greatest distance to the root.")
                         elif len(split_node_name) == 1:
                             pass
                         else:
-                            raise Exception("Malformed node name: %s" % node.name)
+                            raise Exception("Malformed node name: %s" % ancestor.name)
                         
                 tax_list = list(reversed(ancestor_tax))
                 tax_name = tip.name.replace(" ", "_")
@@ -178,7 +178,7 @@ is the greatest distance to the root.")
                     elif len(split_node_name) == 1:
                         pass
                     else:
-                        raise Exception("Malformed node name: %s" % node.name)
+                        raise Exception("Malformed node name: %s" % ancestor.name)
                 if ai > current_index:
                     current_index = ai
             


### PR DESCRIPTION
graftm/tree_decorator.py (_get_tax_index, _write_consensus_strings): Refer to
correct variable when reporting malformed node name.