### PR TITLE
decorate: Add ability to decorate trees with <7 levels of taxonomy.

### DIFF
--- a/graftm/tree_decorator.py
+++ b/graftm/tree_decorator.py
@@ -30,7 +30,6 @@ class TreeDecorator:
         Set up empty lists and open and import tree object, and load the
         taxonomy into a hash
         '''
-        
         self.gg_prefixes = ["k__", "d__", 'p__', 'c__', 'o__', 'f__', 'g__', 's__']
         
         # Set empty list to record nodes that have already been assigned
@@ -42,15 +41,10 @@ class TreeDecorator:
         self.tree = tree
         
         # Read in taxonomy
-        
         if seqinfo:
             gtns = Getaxnseq()
             logging.info("Importing taxtastic taxonomy from files: %s and %s" % (taxonomy, seqinfo))
             self.taxonomy =  gtns.read_taxtastic_taxonomy_and_seqinfo(open(taxonomy), open(seqinfo))
-            
-            for id, taxonomy_list in self.taxonomy.iteritems():
-                if len(taxonomy_list) != MAX_RESOLUTION:
-                    self.taxonomy[id] = taxonomy_list + self.gg_prefixes[1:][len(taxonomy_list):]
         else:
             logging.info("Importing greengenes taxonomy from file: %s" % (taxonomy))
             self.taxonomy = GreenGenesTaxonomy.read_file(taxonomy).taxonomy
@@ -114,7 +108,7 @@ is the greatest distance to the root.")
         return to_return
     
     def _write_tree(self, output):
-        '''Just Writes tree to file uisng scikit-bio'''
+        '''Just Writes tree to file using scikit-bio'''
         logging.info("Writing decorated tree to file: %s" % (output))
         self.tree.write(
                     output,


### PR DESCRIPTION
graftm/tree_decorator.py(_transpose_taxonomy): Rename to
_unique_taxonomy. Remove hard-coded expectation of 7 levels.