### PR TITLE
create: test package works after creation

### DIFF
--- a/graftm/create.py
+++ b/graftm/create.py
@@ -821,6 +821,18 @@ in the final GraftM package. If you are sure these sequences are correct, turn o
         logging.info("Cleaning up")
         self._cleanup(self.the_trash)
 
+        # Test out the gpkg just to be sure.
+        #
+        # TODO: Use graftM through internal means rather than via extern. This
+        # requires some refactoring so that graft() can be called easily with
+        # sane defaults.
+        logging.info("Testing gpkg package works")
+        temp_output = tempdir.TempDir()
+        cmd = "graftM graft --forward '%s' --graftm_package '%s' --output '%s'" %(
+            sequences, output_gpkg_path, temp_output)
+        extern.run(cmd)
+        temp_output.dissolve()
+
         logging.info("Finished\n")
 
     def update(self, input_sequence_path, input_taxonomy_path,


### PR DESCRIPTION
I got sick of create going through but then later getting nasty surprises..

I'd prefer to do something along the lines of
```
Graft().graft(...)
```
But unfortunately `Run` is tightly coupled to argparse (`args` is an instance variable). If we make a new `Graft` class then we might need to also define a `Graft.DEFAULT_PARAMETERS` so that defaults can be specified in `bin/graftM` and in the method definition of `Graft.graft` without repetition (repetition might mean they become out of sync, which would be bad). ..future work.