### PR TITLE
Geronimp investigating pplacer issue rereplicate jplace files

### DIFF
--- a/graftm/pplacer.py
+++ b/graftm/pplacer.py
@@ -121,14 +121,6 @@ class Pplacer:
         # Run pplacer on merged file
         jplace = self.pplacer(files.jplace_output_path(), args.output_directory, files.comb_aln_fa(), args.threads)
         logging.info("Placements finished")
-
-        # Split the original jplace file
-        # and write split jplaces to separate file directories
-        jplace_json = json.load(open(jplace))
-        alias_hash_with_placements = self.jplace_split(jplace_json, 
-                                                       alias_hash)
-        self.write_jplace(jplace_json, 
-                          alias_hash_with_placements)
         
         #Read the json of refpkg
         logging.info("Reading classifications")
@@ -162,6 +154,14 @@ class Pplacer:
                 trusted_placements[base_file]={}
                 for read, entry in classifications[str(idx)].iteritems():
                     trusted_placements[base_file][read] = entry['placement']
+        
+        # Split the original jplace file
+        # and write split jplaces to separate file directories
+        jplace_json = json.load(open(jplace))
+        alias_hash_with_placements = self.jplace_split(jplace_json, 
+                                                       alias_hash)
+        self.write_jplace(jplace_json, 
+                          alias_hash_with_placements)
         
         return trusted_placements
 

--- a/graftm/pplacer.py
+++ b/graftm/pplacer.py
@@ -40,7 +40,7 @@ class Pplacer:
                 for record in alignments: # For each record in the read list
                     record.id = record.id + '_' + str(file_number) # append the unique identifier to the record id
                 SeqIO.write(alignments, output, "fasta") # And write the reads to the file
-                alias_hash[str(file_number)] = {'output_path': os.path.join(os.path.dirname(alignment_file),'placements.jplace'),
+                alias_hash[str(file_number)] = {'output_path': os.path.join(os.path.dirname(alignment_file), 'placements.jplace'),
                                                 'place': []}
                 file_number += 1
         return alias_hash
@@ -69,6 +69,7 @@ class Pplacer:
                 placement_hash = {'p': p,
                                   'nm': nm_list}                
                 alias_hash[alias_idx]['place'].append(placement_hash)
+
         return alias_hash
     
     def write_jplace(self, original_jplace, alias_hash):

--- a/graftm/pplacer.py
+++ b/graftm/pplacer.py
@@ -50,16 +50,23 @@ class Pplacer:
 
         # Load the placement file
         placement_file = json.load(open(jplace_file))
-
+        
         # Parse the placements based on unique identifies appended to the end
         # of each read
         for placement in placement_file['placements']: # for each placement
             hash = {} # create an empty hash
             for alias in alias_hash: # For each alias, append to the 'place' list each read that identifier
-                hash = {'p': placement['p'],
-                        'nm': [nm for nm in placement['nm'] if nm[0].split('_')[-1] == alias]}
-                alias_hash[alias]['place'].append(hash)
-
+                nm_list = []
+                p = placement['p']
+                for nm in placement['nm']:
+                    if nm[0].split('_')[-1] == alias:
+                        nm_list.append(nm)
+                if any(nm_list):
+                    hash = {'p': p,
+                            'nm': nm_list}
+                    alias_hash[alias]['place'].append(hash)
+                else:
+                    continue
         # Write the jplace file to their respective file paths.
         jplace_path_list = []
         for alias in alias_hash:

--- a/graftm/pplacer.py
+++ b/graftm/pplacer.py
@@ -76,7 +76,7 @@ class Pplacer:
                       'placements' : alias_hash[alias]['place'],
                       'metadata'   : placement_file['metadata']}
             with open(alias_hash[alias]['output_path'], 'w') as output_path:
-                json.dump(output, output_path, ensure_ascii=False)
+                json.dump(output, output_path, ensure_ascii=False, indent=3, separators=(',', ': '))
             jplace_path_list.append(alias_hash[alias]['output_path'])
         return jplace_path_list
     

--- a/graftm/pplacer.py
+++ b/graftm/pplacer.py
@@ -86,6 +86,21 @@ class Pplacer:
         alias_hash : dict
             Stores information on each input read file given to GraftM, the
             corresponding reads found within each file, and their taxonomy
+            e.g.
+                {'0': {'output_path': 'GraftM_output/pair_slash.1/placements.jplace',
+                       'place': []}}
+                
+                Each key (alias) in this dictionary is a unique identifier for 
+                an input sequence provided to GraftM. The "output path" key of 
+                the file's alias entry is the file to which the placements 
+                extracted from that input file will be written to. The "place"
+                key is filled out by this function and will store a list of read
+                placements (in jplace v3 format) for that file, for example:
+                [{'nm': [['example_read_name', 1]],
+                  'p': [[u'f__mitochondria',0.0338801262607,4,1,-1208.68889811,0.0491111604489]]},
+                  ...,
+                  ...]
+                  and so on.
         cluster_dict : dict
             dictionary stores information on pre-placement clustering  
         
@@ -94,7 +109,7 @@ class Pplacer:
         Updated alias_hash dict containing placement hashes to write to 
         new jplace file.
         '''       
-        
+
         for placement in original_jplace['placements']: # for each placement
             
             alias_placements_list = []
@@ -120,7 +135,6 @@ class Pplacer:
                 placement_hash = {'p': p,
                                   'nm': nm_list}                
                 alias_hash[alias_idx]['place'].append(placement_hash)
-
         return alias_hash
     
     def write_jplace(self, original_jplace, alias_hash):

--- a/graftm/pplacer.py
+++ b/graftm/pplacer.py
@@ -327,4 +327,3 @@ class Compare:
                     raise Exception('Programming Error: Comparison of placement resolution')               
              
         return comparison_hash # Return the hash
-

--- a/graftm/pplacer.py
+++ b/graftm/pplacer.py
@@ -101,14 +101,21 @@ class Pplacer:
             nm_dict = {}
             p = placement['p']
             for nm in placement['nm']:
-                read_alias_idx = nm[0].split('_')[-1] # Split the alias 
+                nm_list = []
+                placement_read_name, plval = nm
+                read_alias_idx = placement_read_name.split('_')[-1] # Split the alias 
                                     # index out of the read name, which 
                                     # corresponds to the input file from 
                                     # which the read originated.
+                read_name = '_'.join(placement_read_name.split('_')[:-1])
+                read_cluster = cluster_dict[read_alias_idx][read_name]
+                for read in read_cluster:
+                    nm_list.append([read.name, plval])
                 if read_alias_idx not in nm_dict:
-                    nm_dict[read_alias_idx] = [nm]
+                    nm_dict[read_alias_idx] = nm_list
                 else:
-                    nm_dict[read_alias_idx].append(nm)
+                    nm_dict[read_alias_idx] += nm
+                
             for alias_idx, nm_list in nm_dict.iteritems():
                 placement_hash = {'p': p,
                                   'nm': nm_list}                

--- a/graftm/run.py
+++ b/graftm/run.py
@@ -436,8 +436,8 @@ class Run:
         if self.args.assignment_method == Run.PPLACER_TAXONOMIC_ASSIGNMENT:
             # Classification steps        
             if not self.args.no_clustering:
-                C=Clusterer()
-                seqs_list=C.cluster(seqs_list, REVERSE_PIPE)
+                clusterer=Clusterer()
+                seqs_list=clusterer.cluster(seqs_list, REVERSE_PIPE)
             logging.info("Placing reads into phylogenetic tree")
             taxonomic_assignment_time, assignments=self.p.place(REVERSE_PIPE,
                                                                 seqs_list,
@@ -445,9 +445,10 @@ class Run:
                                                                 self.gmf,
                                                                 self.args,
                                                                 result.slash_endings,
-                                                                gpkg.taxtastic_taxonomy_path())
+                                                                gpkg.taxtastic_taxonomy_path(),
+                                                                clusterer)
             if not self.args.no_clustering:
-                assignments = C.uncluster_annotations(assignments, REVERSE_PIPE)
+                assignments = clusterer.uncluster_annotations(assignments, REVERSE_PIPE)
         
         elif self.args.assignment_method == Run.DIAMOND_TAXONOMIC_ASSIGNMENT:
             logging.info("Assigning taxonomy with diamond")

--- a/graftm/run.py
+++ b/graftm/run.py
@@ -432,11 +432,11 @@ class Run:
         self.gmf = GraftMFiles('',
                                self.args.output_directory,
                                False)
-
+        
         if self.args.assignment_method == Run.PPLACER_TAXONOMIC_ASSIGNMENT:
+            clusterer=Clusterer()
             # Classification steps        
             if not self.args.no_clustering:
-                clusterer=Clusterer()
                 seqs_list=clusterer.cluster(seqs_list, REVERSE_PIPE)
             logging.info("Placing reads into phylogenetic tree")
             taxonomic_assignment_time, assignments=self.p.place(REVERSE_PIPE,

--- a/test/test_graft.py
+++ b/test/test_graft.py
@@ -116,10 +116,9 @@ CATGACGTCAGTCCCGGAGACGTTGTACGGCATAAGTTGCCGCTGACCAAGCGTCATACCGCCGAGGTGCACGTTGACGT
                 placements_file = os.path.join(tmp, sample_name, "placements.jplace")
                 open_placements_file = json.load(open(placements_file))
                 self.assertEqual(len(open_placements_file["placements"]), 3)
-              
-                placements = sorted((u'HWI-ST1243:121:D1AF9ACXX:8:1101:4414:35570_2_2_3_0', 
-                                     u'HWI-ST1243:121:D1AF9ACXX:8:1101:14973:25766_1_4_3_0', 
-                                     u'HWI-ST1243:121:D1AF9ACXX:8:1101:12684:12444_2_1_1_2_0'))
+                placements = sorted((u'HWI-ST1243:121:D1AF9ACXX:8:1101:4414:35570_2_2_3', 
+                                     u'HWI-ST1243:121:D1AF9ACXX:8:1101:12684:12444_2_1_1_2',
+                                     u'HWI-ST1243:121:D1AF9ACXX:8:1101:14973:25766_1_4_3'))
                 for idx, placed_read_name in enumerate(sorted(tuple([y[0] for y in [x['nm'][0] for x in open_placements_file["placements"]]]))):
                     self.assertEqual(placements[idx], placed_read_name)
                                                 

--- a/test/test_json_placement_split.py
+++ b/test/test_json_placement_split.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+
+#=======================================================================
+# Authors: Ben Woodcroft, Joel Boyd
+#
+# Unit tests.
+#
+# Copyright
+#
+# This is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License.
+# If not, see <http://www.gnu.org/licenses/>.
+#=======================================================================
+
+import unittest
+import os
+import sys
+from graftm.pplacer import Pplacer
+
+
+sys.path = [os.path.join(os.path.dirname(os.path.realpath(__file__)),'..')]+sys.path
+
+class HmmsearcherTests(unittest.TestCase):
+    path_to_data = os.path.join(os.path.dirname(os.path.realpath(__file__)),'data')
+    
+    def test_basic_split(self):
+        input_alias_hash = {'0':{'place':[]}, '1':{'place':[]}}
+        placement=['p__Proteobacteria', 'k__Bacteria', 'p__Proteobacteria']
+
+        test_json = {"fields":
+                      ["classification", "distal_length", "edge_num", "like_weight_ratio",
+                        "likelihood", "pendant_length"
+                      ], "tree":
+                      "((696036:0.2205{0},229854:0.20827{1})1.000:0.14379{2},3190878:0.23845{3},2107103:0.32104{4}){5};",
+                      "placements":
+                      [
+                        {"p":
+                          [
+                            ["p__Proteobacteria", 0.107586583111, 1, 0.970420466541,
+                              -614.032176075, 0.22226616471
+                            ],
+                            ["k__Bacteria", 0.220493270874, 0, 0.0147918928965, -618.21582627,
+                              0.248671444337
+                            ],
+                            ["p__Proteobacteria", 8.77624511719e-06, 2, 0.0147876405626,
+                              -618.216113788, 0.248672441848
+                            ]
+                          ], "nm":
+                          [["test_read1_0", 1],
+                            ["test_read2_1", 1]
+                          ]
+                        }
+                      ], "version": 3, "metadata":
+                      {"invocation":
+                        "pplacer -c test_16S.gpkg\/test_16S.gpkg.refpkg\/ GraftM_output\/combined_alignment.aln.fa"
+                      }
+                    }
+        
+        pplacer = Pplacer("refpkg_decoy")
+        
+        output_alias_hash = pplacer.jplace_split(test_json, input_alias_hash)
+        
+        for alias_idx, alias_placement_entry in output_alias_hash.iteritems():
+            
+            placement_dict = alias_placement_entry['place']
+            self.assertEqual(len(placement_dict), 1)
+            self.assertEqual([x[0] for x in placement_dict[0]['p']],
+                             placement)
+        
+    def test_basic_split_with_different_placements(self):
+        input_alias_hash = {'0':{'place':[]}, '1':{'place':[]}}
+        placements1=[['p__Crenarchaeota', 'k__Archaea', 'p__Crenarchaeota'],
+                     ['p__Proteobacteria', 'k__Bacteria', 'c__Alphaproteobacteria']]
+        placements2=[['p__Crenarchaeota', 'k__Archaea', 'p__Crenarchaeota'],
+                     ['k__Bacteria', 'p__Cyanobacteria', 'c__Chloroplast']]
+        placement_results = {'0': placements1, '1':placements2}
+        test_json = {"fields":
+                      ["classification", "distal_length", "edge_num", "like_weight_ratio",
+                        "likelihood", "pendant_length"
+                      ], "tree":
+                      "((696036:0.2205{0},229854:0.20827{1})1.000:0.14379{2},3190878:0.23845{3},2107103:0.32104{4}){5};",
+                      "placements":
+                      [
+                        {"p":
+                          [
+                            ["p__Crenarchaeota", 0.107586583111, 1, 0.970420466541,
+                              -614.032176075, 0.22226616471
+                            ],
+                            ["k__Archaea", 0.220493270874, 0, 0.0147918928965, -618.21582627,
+                              0.248671444337
+                            ],
+                            ["p__Crenarchaeota", 8.77624511719e-06, 2, 0.0147876405626,
+                              -618.216113788, 0.248672441848
+                            ]
+                          ], "nm":
+                          [["test_read1_0", 1],
+                            ["test_read2_1", 1]
+                          ]
+                        }, 
+                        {"p":
+                          [
+                            ["p__Proteobacteria", 0.107586583111, 1, 0.970420466541,
+                              -614.032176075, 0.22226616471
+                            ],
+                            ["k__Bacteria", 0.220493270874, 0, 0.0147918928965, -618.21582627,
+                              0.248671444337
+                            ],
+                            ["c__Alphaproteobacteria", 8.77624511719e-06, 2, 0.0147876405626,
+                              -618.216113788, 0.248672441848
+                            ]
+                          ], "nm":
+                          [["test_read3_0", 1]]
+                        },
+                        {"p":
+                          [
+                            ["k__Bacteria", 0.107586583111, 1, 0.970420466541,
+                              -614.032176075, 0.22226616471
+                            ],
+                            ["p__Cyanobacteria", 0.220493270874, 0, 0.0147918928965, -618.21582627,
+                              0.248671444337
+                            ],
+                            ["c__Chloroplast", 8.77624511719e-06, 2, 0.0147876405626,
+                              -618.216113788, 0.248672441848
+                            ]
+                          ], "nm":
+                          [["test_read4_1", 1]]
+                        }
+                      ], "version": 3, "metadata":
+                      {"invocation":
+                        "pplacer -c test_16S.gpkg\/test_16S.gpkg.refpkg\/ GraftM_output\/combined_alignment.aln.fa"
+                      }
+                    }
+        
+        pplacer = Pplacer("refpkg_decoy")
+        output_alias_hash = pplacer.jplace_split(test_json, input_alias_hash)
+        for alias_idx, alias_placement_entry in output_alias_hash.iteritems():
+            placement_dict = alias_placement_entry['place']
+            self.assertEqual(len(placement_dict), 2)
+            self.assertEqual([x[0] for x in placement_dict[0]['p']],
+                             placement_results[alias_idx][0])
+            self.assertEqual([x[0] for x in placement_dict[1]['p']],
+                             placement_results[alias_idx][1])
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_json_placement_split.py
+++ b/test/test_json_placement_split.py
@@ -37,46 +37,37 @@ class Tests(unittest.TestCase):
         expected_placement=['p__Proteobacteria', 'k__Bacteria', 'p__Proteobacteria']
         mock_cluster_hash = {'0':  {"test_read1": [Sequence("test_read1", "SEQUENCE")]},
                              '1':  {"test_read2": [Sequence("test_read2", "SEQUENCE")]}}
-        test_json = {"fields":
-                      ["classification", "distal_length", "edge_num", "like_weight_ratio",
-                        "likelihood", "pendant_length"
-                      ], "tree":
-                      "((696036:0.2205{0},229854:0.20827{1})1.000:0.14379{2},3190878:0.23845{3},2107103:0.32104{4}){5};",
-                      "placements":
-                      [
-                        {"p":
-                          [
-                            ["p__Proteobacteria", 0.107586583111, 1, 0.970420466541,
-                              -614.032176075, 0.22226616471
-                            ],
-                            ["k__Bacteria", 0.220493270874, 0, 0.0147918928965, -618.21582627,
-                              0.248671444337
-                            ],
-                            ["p__Proteobacteria", 8.77624511719e-06, 2, 0.0147876405626,
-                              -618.216113788, 0.248672441848
-                            ]
-                          ], "nm":
-                          [["test_read1_0", 1],
-                            ["test_read2_1", 1]
-                          ]
-                        }
-                      ], "version": 3, "metadata":
-                      {"invocation":
-                        "pplacer -c test_16S.gpkg\/test_16S.gpkg.refpkg\/ GraftM_output\/combined_alignment.aln.fa"
-                      }
-                    }
+        test_json = {
+                     "fields":["classification", "distal_length", "edge_num", "like_weight_ratio", "likelihood", "pendant_length"], 
+                     "tree":"((696036:0.2205{0},229854:0.20827{1})1.000:0.14379{2},3190878:0.23845{3},2107103:0.32104{4}){5};",
+                     "placements":[{"p":  [["p__Proteobacteria", 0.107586583111, 1, 0.970420466541, -614.032176075, 0.22226616471],
+                                           ["k__Bacteria", 0.220493270874, 0, 0.0147918928965, -618.21582627, 0.248671444337],
+                                           ["p__Proteobacteria", 8.77624511719e-06, 2, 0.0147876405626, -618.216113788, 0.248672441848]], 
+                                    "nm": [["test_read1_0", 1], ["test_read2_1", 1]]}], 
+                     "version": 3, 
+                     "metadata": {"invocation": "pplacer -c test_16S.gpkg\/test_16S.gpkg.refpkg\/ GraftM_output\/combined_alignment.aln.fa"}
+                     }
         
         pplacer = Pplacer("refpkg_decoy")
         
         output_alias_hash = pplacer.jplace_split(test_json, input_alias_hash, mock_cluster_hash)
         
-        expected_placement = ['p__Proteobacteria', 'k__Bacteria', 'p__Proteobacteria']
+        expected_placements = [{"p": [["p__Proteobacteria", 0.107586583111, 1, 0.970420466541, -614.032176075, 0.22226616471],
+                                       ["k__Bacteria", 0.220493270874, 0, 0.0147918928965, -618.21582627, 0.248671444337],
+                                       ["p__Proteobacteria", 8.77624511719e-06, 2, 0.0147876405626, -618.216113788, 0.248672441848]], 
+                                "nm":[["test_read1", 1]]},
+                               {"p": [["p__Proteobacteria", 0.107586583111, 1, 0.970420466541, -614.032176075, 0.22226616471],
+                                       ["k__Bacteria", 0.220493270874, 0, 0.0147918928965, -618.21582627, 0.248671444337],
+                                       ["p__Proteobacteria", 8.77624511719e-06, 2, 0.0147876405626, -618.216113788, 0.248672441848]], 
+                                "nm": [["test_read2", 1]]}]
+                                
         expected_number_of_placements = 1
         
         for alias_idx, alias_placement_entry in output_alias_hash.items():
+            expected_placement = expected_placements.pop()
             placement_dict = alias_placement_entry['place']
             observed_number_of_placements = len(placement_dict)
-            observed_placement = [x[0] for x in placement_dict[0]['p']]
+            observed_placement = placement_dict[0]
             self.assertEqual(expected_number_of_placements, 
                              observed_number_of_placements)
             self.assertEqual(expected_placement,
@@ -152,30 +143,37 @@ class Tests(unittest.TestCase):
         output_alias_hash = pplacer.jplace_split(test_json, input_alias_hash, mock_cluster_hash)
         
         expected_number_of_placements   = 2
-        expected_placements_for_alias_0 = [['p__Crenarchaeota', 'k__Archaea', 'p__Crenarchaeota'],
-                                           ['p__Proteobacteria', 'k__Bacteria', 'c__Alphaproteobacteria']]
-        expected_placements_for_alias_1 = [['p__Crenarchaeota', 'k__Archaea', 'p__Crenarchaeota'],
-                                           ['k__Bacteria', 'p__Cyanobacteria', 'c__Chloroplast']]
+        expected_placements_for_alias_0 = [{"p":[["p__Crenarchaeota", 0.107586583111, 1, 0.970420466541, -614.032176075, 0.22226616471],
+                                                 ["k__Archaea", 0.220493270874, 0, 0.0147918928965, -618.21582627, 0.248671444337], 
+                                                 ["p__Crenarchaeota", 8.77624511719e-06, 2, 0.0147876405626, -618.216113788, 0.248672441848]], 
+                                            "nm": [["test_read1", 1]]},
+                                           {"p":[["p__Proteobacteria", 0.107586583111, 1, 0.970420466541, -614.032176075, 0.22226616471],
+                                                 ["k__Bacteria", 0.220493270874, 0, 0.0147918928965, -618.21582627, 0.248671444337],
+                                                 ["c__Alphaproteobacteria", 8.77624511719e-06, 2, 0.0147876405626, -618.216113788, 0.248672441848]],
+                                            "nm":[["test_read3", 1]]}]
+        
+        expected_placements_for_alias_1 = [{"p":[["p__Crenarchaeota", 0.107586583111, 1, 0.970420466541, -614.032176075, 0.22226616471],
+                                                 ["k__Archaea", 0.220493270874, 0, 0.0147918928965, -618.21582627, 0.248671444337], 
+                                                 ["p__Crenarchaeota", 8.77624511719e-06, 2, 0.0147876405626, -618.216113788, 0.248672441848]], 
+                                            "nm": [["test_read2", 1]]},
+                                           {"p":[["k__Bacteria", 0.107586583111, 1, 0.970420466541, -614.032176075, 0.22226616471],
+                                                 ["p__Cyanobacteria", 0.220493270874, 0, 0.0147918928965, -618.21582627, 0.248671444337],
+                                                 ["c__Chloroplast", 8.77624511719e-06, 2, 0.0147876405626, -618.216113788, 0.248672441848]],
+                                            "nm":[["test_read4", 1]]}]     
+        
         placement_results               = {'0': expected_placements_for_alias_0, 
                                            '1': expected_placements_for_alias_1}
         
         for alias_idx, alias_placement_entry in output_alias_hash.items():
             
-            placement_dict                   = alias_placement_entry['place']
             expected_placement_results       = placement_results[alias_idx]
-            expected_placement_results_read1 = expected_placement_results[0]
-            expected_placement_results_read2 = expected_placement_results[1]
-            
-            observed_number_of_placements    = len(placement_dict)
-            observed_placement_resilt_read1  = [x[0] for x in placement_dict[0]['p']]
-            observed_placement_resilt_read2  = [x[0] for x in placement_dict[1]['p']]
+            observed_placement_results       = alias_placement_entry['place']
+            observed_number_of_placements    = len(observed_placement_results)
 
             self.assertEqual(expected_number_of_placements, 
                              observed_number_of_placements)
-            self.assertEqual(expected_placement_results_read1,
-                             observed_placement_resilt_read1)
-            self.assertEqual(expected_placement_results_read2,
-                             observed_placement_resilt_read2)
+            self.assertEqual(expected_placement_results,
+                             observed_placement_results)
             
     def test_rereplicating_json_file(self):
         input_alias_hash = {'0':{'place':[]}}
@@ -202,7 +200,7 @@ class Tests(unittest.TestCase):
                               -618.216113788, 0.248672441848
                             ]
                           ], "nm":
-                          [["test_read1_0", 1]                          ]
+                          [["test_read1_0", 1]]
                         }
                       ], "version": 3, "metadata":
                       {"invocation":
@@ -213,20 +211,19 @@ class Tests(unittest.TestCase):
         pplacer = Pplacer("refpkg_decoy")
         
         output_alias_hash = pplacer.jplace_split(test_json, input_alias_hash, mock_cluster_hash)
-        expected_placement_results = ['p__Proteobacteria', 'k__Bacteria', 'p__Proteobacteria']
-        execeted_number_of_placements = 1
-        expected_number_of_reads_in_placement = 2
+        
+        expected_placement_results = {
+                                      "p":[["p__Proteobacteria", 0.107586583111, 1, 0.970420466541, -614.032176075, 0.22226616471],
+                                           ["k__Bacteria", 0.220493270874, 0, 0.0147918928965, -618.21582627, 0.248671444337],
+                                           ["p__Proteobacteria", 8.77624511719e-06, 2, 0.0147876405626, -618.216113788, 0.248672441848]],
+                                      "nm":[["test_read1", 1],
+                                            ["test_read2", 1]]
+                                      }
+        
         for alias_placement_entry in output_alias_hash.values():
             placement_dict = alias_placement_entry['place']
-
-            observed_placement_results             = [x[0] for x in placement_dict[0]['p']]
+            observed_placement_results             = placement_dict[0]
             observed_number_of_placements          = len(placement_dict)
-            observed_number_of_reads_in_placement  = len(placement_dict[0]['nm'])
-            
-            self.assertEqual(execeted_number_of_placements,
-                             execeted_number_of_placements)
-            self.assertEqual(expected_number_of_reads_in_placement,
-                             expected_number_of_reads_in_placement)
             self.assertEqual(expected_placement_results,
                              observed_placement_results)
 

--- a/test/test_json_placement_split.py
+++ b/test/test_json_placement_split.py
@@ -50,28 +50,19 @@ class Tests(unittest.TestCase):
         
         pplacer = Pplacer("refpkg_decoy")
         
-        output_alias_hash = pplacer.jplace_split(test_json, input_alias_hash, mock_cluster_hash)
+        observed_placement = pplacer.jplace_split(test_json, mock_cluster_hash)
         
-        expected_placements = [{"p": [["p__Proteobacteria", 0.107586583111, 1, 0.970420466541, -614.032176075, 0.22226616471],
-                                       ["k__Bacteria", 0.220493270874, 0, 0.0147918928965, -618.21582627, 0.248671444337],
-                                       ["p__Proteobacteria", 8.77624511719e-06, 2, 0.0147876405626, -618.216113788, 0.248672441848]], 
-                                "nm":[["test_read1", 1]]},
-                               {"p": [["p__Proteobacteria", 0.107586583111, 1, 0.970420466541, -614.032176075, 0.22226616471],
-                                       ["k__Bacteria", 0.220493270874, 0, 0.0147918928965, -618.21582627, 0.248671444337],
-                                       ["p__Proteobacteria", 8.77624511719e-06, 2, 0.0147876405626, -618.216113788, 0.248672441848]], 
-                                "nm": [["test_read2", 1]]}]
-                                
-        expected_number_of_placements = 1
-        
-        for alias_idx, alias_placement_entry in output_alias_hash.items():
-            expected_placement = expected_placements.pop()
-            placement_dict = alias_placement_entry['place']
-            observed_number_of_placements = len(placement_dict)
-            observed_placement = placement_dict[0]
-            self.assertEqual(expected_number_of_placements, 
-                             observed_number_of_placements)
-            self.assertEqual(expected_placement,
-                             observed_placement)
+        expected_placement = {'0':[{"p": [["p__Proteobacteria", 0.107586583111, 1, 0.970420466541, -614.032176075, 0.22226616471],
+                                           ["k__Bacteria", 0.220493270874, 0, 0.0147918928965, -618.21582627, 0.248671444337],
+                                           ["p__Proteobacteria", 8.77624511719e-06, 2, 0.0147876405626, -618.216113788, 0.248672441848]], 
+                                     "nm":[["test_read1", 1]]}],
+                               '1': [{"p": [["p__Proteobacteria", 0.107586583111, 1, 0.970420466541, -614.032176075, 0.22226616471],
+                                           ["k__Bacteria", 0.220493270874, 0, 0.0147918928965, -618.21582627, 0.248671444337],
+                                           ["p__Proteobacteria", 8.77624511719e-06, 2, 0.0147876405626, -618.216113788, 0.248672441848]], 
+                                     "nm": [["test_read2", 1]]}]}
+
+        self.assertEqual(expected_placement,
+                         observed_placement)
         
     def test_basic_split_with_different_placements(self):
         input_alias_hash = {'0':{'place':[]}, '1':{'place':[]}}
@@ -140,40 +131,35 @@ class Tests(unittest.TestCase):
                     }
         
         pplacer = Pplacer("refpkg_decoy")
-        output_alias_hash = pplacer.jplace_split(test_json, input_alias_hash, mock_cluster_hash)
+        observed_placement_results = pplacer.jplace_split(test_json, mock_cluster_hash)
         
-        expected_number_of_placements   = 2
-        expected_placements_for_alias_0 = [{"p":[["p__Crenarchaeota", 0.107586583111, 1, 0.970420466541, -614.032176075, 0.22226616471],
+        expected_placement_results = {'0': [{"p":[["p__Crenarchaeota", 0.107586583111, 1, 0.970420466541, -614.032176075, 0.22226616471],
                                                  ["k__Archaea", 0.220493270874, 0, 0.0147918928965, -618.21582627, 0.248671444337], 
                                                  ["p__Crenarchaeota", 8.77624511719e-06, 2, 0.0147876405626, -618.216113788, 0.248672441848]], 
                                             "nm": [["test_read1", 1]]},
-                                           {"p":[["p__Proteobacteria", 0.107586583111, 1, 0.970420466541, -614.032176075, 0.22226616471],
+                                           {
+                                            "p":[["p__Proteobacteria", 0.107586583111, 1, 0.970420466541, -614.032176075, 0.22226616471],
                                                  ["k__Bacteria", 0.220493270874, 0, 0.0147918928965, -618.21582627, 0.248671444337],
                                                  ["c__Alphaproteobacteria", 8.77624511719e-06, 2, 0.0147876405626, -618.216113788, 0.248672441848]],
-                                            "nm":[["test_read3", 1]]}]
-        
-        expected_placements_for_alias_1 = [{"p":[["p__Crenarchaeota", 0.107586583111, 1, 0.970420466541, -614.032176075, 0.22226616471],
+                                            "nm":[["test_read3", 1]]
+                                            }],
+                               '1':  
+                                            [{
+                                             "p":[["p__Crenarchaeota", 0.107586583111, 1, 0.970420466541, -614.032176075, 0.22226616471],
                                                  ["k__Archaea", 0.220493270874, 0, 0.0147918928965, -618.21582627, 0.248671444337], 
                                                  ["p__Crenarchaeota", 8.77624511719e-06, 2, 0.0147876405626, -618.216113788, 0.248672441848]], 
-                                            "nm": [["test_read2", 1]]},
-                                           {"p":[["k__Bacteria", 0.107586583111, 1, 0.970420466541, -614.032176075, 0.22226616471],
+                                            "nm": [["test_read2", 1]]
+                                            },
+                                            {
+                                             "p":[["k__Bacteria", 0.107586583111, 1, 0.970420466541, -614.032176075, 0.22226616471],
                                                  ["p__Cyanobacteria", 0.220493270874, 0, 0.0147918928965, -618.21582627, 0.248671444337],
                                                  ["c__Chloroplast", 8.77624511719e-06, 2, 0.0147876405626, -618.216113788, 0.248672441848]],
-                                            "nm":[["test_read4", 1]]}]     
-        
-        placement_results               = {'0': expected_placements_for_alias_0, 
-                                           '1': expected_placements_for_alias_1}
-        
-        for alias_idx, alias_placement_entry in output_alias_hash.items():
-            
-            expected_placement_results       = placement_results[alias_idx]
-            observed_placement_results       = alias_placement_entry['place']
-            observed_number_of_placements    = len(observed_placement_results)
+                                             "nm":[["test_read4", 1]]
+                                             }]
+                                      
+                               }
 
-            self.assertEqual(expected_number_of_placements, 
-                             observed_number_of_placements)
-            self.assertEqual(expected_placement_results,
-                             observed_placement_results)
+        self.assertEqual(expected_placement_results, observed_placement_results)
             
     def test_rereplicating_json_file(self):
         input_alias_hash = {'0':{'place':[]}}
@@ -210,22 +196,17 @@ class Tests(unittest.TestCase):
         
         pplacer = Pplacer("refpkg_decoy")
         
-        output_alias_hash = pplacer.jplace_split(test_json, input_alias_hash, mock_cluster_hash)
+        observed_placement_results = pplacer.jplace_split(test_json, mock_cluster_hash)
         
-        expected_placement_results = {
-                                      "p":[["p__Proteobacteria", 0.107586583111, 1, 0.970420466541, -614.032176075, 0.22226616471],
+        expected_placement_results = {'0': 
+                                      [{"p":[["p__Proteobacteria", 0.107586583111, 1, 0.970420466541, -614.032176075, 0.22226616471],
                                            ["k__Bacteria", 0.220493270874, 0, 0.0147918928965, -618.21582627, 0.248671444337],
                                            ["p__Proteobacteria", 8.77624511719e-06, 2, 0.0147876405626, -618.216113788, 0.248672441848]],
                                       "nm":[["test_read1", 1],
-                                            ["test_read2", 1]]
-                                      }
+                                            ["test_read2", 1]]}]}
         
-        for alias_placement_entry in output_alias_hash.values():
-            placement_dict = alias_placement_entry['place']
-            observed_placement_results             = placement_dict[0]
-            observed_number_of_placements          = len(placement_dict)
-            self.assertEqual(expected_placement_results,
-                             observed_placement_results)
+        self.assertEqual(expected_placement_results,
+                        observed_placement_results)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Passes all tests except slash error. This addresses the issue pointed out in the unmerged branch https://github.com/geronimp/graftM/pull/165 where the output placement files are not filled out with replicates (i.e. only de-replicated sequences are in the placement files).

I've fixed this issue, added a test and also removed the file aliases appended to the end of each sequence name in the jplace files. See commit comments below for specifics of the changes.

Joel