### PR TITLE
test_graft: add test for --no_clustering

### DIFF
--- a/test/test_graft.py
+++ b/test/test_graft.py
@@ -1324,6 +1324,18 @@ CGGGAGGAACACCAGTGGCGAAGGCGGCTTCCTGGCCTGTTCTTGACGCTGAGGCGCGAA
             self.assertTrue(os.path.exists(os.path.join(tmp, "combined_count_table.txt")))
             self.assertFalse(os.path.exists(os.path.join(tmp, "krona.html")))
 
+    def test_no_clustering(self):
+        reads_1=os.path.join(path_to_samples, "sample_16S_1.1.fa")
+        gpkg=os.path.join(path_to_data, "61_otus.gpkg")
+        
+        with tempdir.TempDir() as tmp:
+            cmd = '%s graft --verbosity 5  --forward %s --graftm_package %s --output_directory %s --force --no_clustering' % (
+                path_to_script,
+                reads_1,
+                gpkg,
+                tmp)
+            extern.run(cmd)
+            self.assertTrue(os.path.exists(os.path.join(tmp, "combined_count_table.txt")))
         
                     
 if __name__ == "__main__":


### PR DESCRIPTION
Unfortunately, it's a failing test. Any ideas?
```
$ python test/test_graft.py Tests.test_no_clustering
E
======================================================================
ERROR: test_no_clustering (__main__.Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_graft.py", line 1337, in test_no_clustering
    extern.run(cmd)
  File "/usr/local/lib/python2.7/dist-packages/extern/__init__.py", line 41, in run
    stdout)
ExternCalledProcessError: Command /home/ben/git/graftM/test/../bin/graftM graft --verbosity 5  --forward /home/ben/git/graftM/test/sample_runs/sample_16S_1.1.fa --graftm_package /home/ben/git/graftM/test/data/61_otus.gpkg --output_directory /tmp/tmpfhaW5J --force --no_clustering returned non-zero exit status 1.
STDERR was: 05/23/2016 09:06:56 PM DEBUG: Ran command: /home/ben/git/graftM/test/../bin/graftM graft --verbosity 5 --forward /home/ben/git/graftM/test/sample_runs/sample_16S_1.1.fa --graftm_package /home/ben/git/graftM/test/data/61_otus.gpkg --output_directory /tmp/tmpfhaW5J --force --no_clustering
05/23/2016 09:06:56 PM DEBUG: Loading version 3 GraftM package: /home/ben/git/graftM/test/data/61_otus.gpkg
05/23/2016 09:06:56 PM DEBUG: Loading version 3 GraftM package: /home/ben/git/graftM/test/data/61_otus.gpkg
05/23/2016 09:06:56 PM DEBUG: Creating working directory: /tmp/tmpfhaW5J
05/23/2016 09:06:56 PM DEBUG: HMM type: D Trusted Cutoff: None
05/23/2016 09:06:56 PM DEBUG: Working with 1 file(s)
05/23/2016 09:06:56 PM INFO: Working on sample_16S_1.1
05/23/2016 09:06:56 PM DEBUG: Running nucleotide pipeline
05/23/2016 09:06:56 PM DEBUG: Using 1 HMMs to search
05/23/2016 09:06:56 PM DEBUG: Detected file format FORMAT_FASTA
05/23/2016 09:06:56 PM DEBUG: raw read unpacking command chunk: cat /home/ben/git/graftM/test/sample_runs/sample_16S_1.1.fa
05/23/2016 09:06:56 PM DEBUG: Running command: cat /home/ben/git/graftM/test/sample_runs/sample_16S_1.1.fa | nhmmer --incE 1e-5 -E 1e-5 --cpu 5 -o /dev/null --noali --tblout /tmp/tmpfhaW5J/sample_16S_1.1/sample_16S_1.1.hmmout.csv /home/ben/git/graftM/test/data/61_otus.gpkg/61_otus.hmm -
05/23/2016 09:06:56 PM DEBUG: Running extern cmd: cat /home/ben/git/graftM/test/sample_runs/sample_16S_1.1.fa | nhmmer --incE 1e-5 -E 1e-5 --cpu 5 -o /dev/null --noali --tblout /tmp/tmpfhaW5J/sample_16S_1.1/sample_16S_1.1.hmmout.csv /home/ben/git/graftM/test/data/61_otus.gpkg/61_otus.hmm -
05/23/2016 09:06:57 PM INFO: 96 read(s) detected
05/23/2016 09:06:57 PM INFO: aligning reads to reference package database
05/23/2016 09:06:57 PM DEBUG: Found 45 forward direction reads
05/23/2016 09:06:57 PM DEBUG: Found 51 reverse direction reads
05/23/2016 09:06:57 PM DEBUG: Writing forward direction reads to /tmp/for_filee5rtMC.fa
05/23/2016 09:06:57 PM DEBUG: Running extern cmd: hmmalign --trim /home/ben/git/graftM/test/data/61_otus.gpkg/61_otus.hmm /tmp/for_filee5rtMC.fa | seqmagick convert --input-format stockholm --output-format fasta - /tmp/for_conv_fileBCWe5u.fa
05/23/2016 09:06:57 PM DEBUG: Writing reverse direction reads to /tmp/rev_file48l3Uf.fa
05/23/2016 09:06:57 PM DEBUG: Running extern cmd: hmmalign --trim /home/ben/git/graftM/test/data/61_otus.gpkg/61_otus.hmm /tmp/rev_file48l3Uf.fa | seqmagick convert --input-format stockholm --output-format fasta - /tmp/rev_conv_fileIx39oU.fa
05/23/2016 09:06:58 PM INFO: Filtered 60 short sequences from the alignment
05/23/2016 09:06:58 PM INFO: 36 sequences remaining
05/23/2016 09:06:58 PM DEBUG: Sorting reads into HMMs by bit score
05/23/2016 09:06:58 PM DEBUG: Writing search otu table to file: /tmp/tmpfhaW5J/search_otu_table.txt
05/23/2016 09:06:58 PM INFO: Placing reads into phylogenetic tree
05/23/2016 09:06:58 PM DEBUG: Running extern cmd: pplacer -j 5 --verbosity 0 --out-dir /tmp/tmpfhaW5J -c /home/ben/git/graftM/test/data/61_otus.gpkg/61_otus.refpkg /tmp/tmpfhaW5J/combined_alignment.aln.fa
05/23/2016 09:06:59 PM INFO: Placements finished
05/23/2016 09:06:59 PM INFO: Reading classifications
05/23/2016 09:06:59 PM INFO: Reads classified
Traceback (most recent call last):
  File "/home/ben/git/graftM/test/../bin/graftM", line 384, in <module>
    Run(args).main()
  File "/home/ben/git/graftM/bin/../graftm/run.py", line 546, in main
    self.graft()
  File "/home/ben/git/graftM/bin/../graftm/run.py", line 450, in graft
    clusterer)
  File "/home/ben/git/graftM/bin/../graftm/timeit.py", line 10, in timed
    result = method(*args, **kw)
  File "/home/ben/git/graftM/bin/../graftm/pplacer.py", line 219, in place
    cluster_dict)
  File "/home/ben/git/graftM/bin/../graftm/pplacer.py", line 115, in jplace_split
    read_cluster = cluster_dict[read_alias_idx][read_name]
KeyError: u'0'
STDOUT was:                          
                             GraftM 0.9.5

                                GRAFT

                       Joel Boyd, Ben Woodcroft

                                                         __/__
                                                  ______|
          _- - _                         ________|      |_____/
           - -            -             |        |____/_
           - _     >>>>  -   >>>>   ____|
          - _-  -         -             |      ______
             - _                        |_____|
           -                                  |______
            


----------------------------------------------------------------------
Ran 1 test in 3.602s

```