### PR TITLE
Remove seqmagick

### DIFF
--- a/graftm/external_program_suite.py
+++ b/graftm/external_program_suite.py
@@ -2,12 +2,11 @@ import extern
 import logging
 
 class ExternalProgramSuite:
-    
+
     _FASTTREE="FastTreeMP"
-    
+
     package_urls = {'taxit': 'https://github.com/fhcrc/taxtastic',
              'FastTree': 'http://www.microbesonline.org/fasttree/',
-             'seqmagick': 'https://github.com/fhcrc/seqmagick',
              'orfm': 'https://github.com/wwood/OrfM',
             'fxtract': 'https://github.com/ctSkennerton/fxtract',
             'pplacer': 'http://matsen.fhcrc.org/pplacer/',
@@ -15,24 +14,24 @@ class ExternalProgramSuite:
             'mafft': 'http://mafft.cbrc.jp/alignment/software/',
             'diamond': 'https://github.com/bbuchfink/diamond',
             'hmmer': 'http://hmmer.janelia.org/'}
-    
+
     programs_to_packages = {'hmmalign': 'hmmer',
                             'hmmsearch': 'hmmer',
                             'nhmmer': 'hmmer',
                             'ktImportText': 'krona',
                             'FastTreeMP': 'FastTree'}
-    
+
     programs_to_possibilities = {
                                  _FASTTREE: ["FastTreeMP",
                                               "fasttree",
                                               "fasttreeMP",
                                               "FastTree"]
                                  }
-    
+
     def __init__(self, program_list):
         '''Given a list of executable names, check that they are available
         on the PATH, raising an exception otherwise
-        
+
         Parameters
         ----------
         program_list: iterable of str
@@ -48,13 +47,13 @@ class ExternalProgramSuite:
                 if len(check)>1:
                     logging.warning("Program found with multiple commands: %s. \
 Arbitrarily selecting %s" % (' '.join(program_list), check[0]))
-                    
+
                 for key, item in ExternalProgramSuite\
                                         .programs_to_possibilities\
                                         .iteritems():
                     if program in item:
                         program = key
-                
+
                 if len(check) > 0:
                     if key == self._FASTTREE:
                         self.fasttree = check[0]
@@ -63,7 +62,7 @@ Arbitrarily selecting %s" % (' '.join(program_list), check[0]))
             else:
                 if not extern.which(program):
                     uninstalled_programs.append(program)
-    
+
         if any(uninstalled_programs):
             msg = "The following programs appear to be missing, and need to be updated or installed before GraftM can continue:"
             logging.error(msg)
@@ -74,6 +73,6 @@ Arbitrarily selecting %s" % (' '.join(program_list), check[0]))
                 except KeyError:
                     package_name = program
                     print_name = program
-                    
+
                 logging.error('\t%25s\t%s' % (print_name, ExternalProgramSuite.package_urls[package_name]))
             exit(1)

--- a/graftm/sequence_searcher.py
+++ b/graftm/sequence_searcher.py
@@ -8,6 +8,7 @@ import subprocess
 
 from Bio import SeqIO
 from collections import OrderedDict
+from StringIO import StringIO
 
 from graftm.timeit import Timer
 from graftm.hmmsearcher import HmmSearcher, NhmmerSearcher
@@ -143,11 +144,12 @@ class SequenceSearcher:
         nothing
         '''
 
-        cmd = 'hmmalign --trim %s %s | seqmagick convert --input-format stockholm --output-format fasta - %s' % (hmm,
-                                                                                           sequences,
-                                                                                           output_file)
-
-        extern.run(cmd)
+        cmd = 'hmmalign --trim %s %s' % (hmm, sequences)
+        process = subprocess.Popen(["bash", "-c", cmd],
+                                   stdout=subprocess.PIPE)
+        output, error = process.communicate()
+        with open(output_file, 'w') as f:
+            SeqIO.write(SeqIO.parse(StringIO(output), 'stockholm'), f, 'fasta')
 
     def makeSequenceBinary(self, sequences, fm):
         cmd = 'makehmmerdb %s %s' % (sequences, fm)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(name='graftm',
       keywords="",
       packages=find_packages(exclude='docs'),
       install_requires=('biopython >=1.64',
-                        'seqmagick >=0.5.0, <0.7.0', # Seqmagick 0.7.0 is python-3 only.
                         'subprocess32 >=3.2.6',
                         'biom-format >=2.1.4',
                         'extern >=0.0.4',

--- a/test/test_create.py
+++ b/test/test_create.py
@@ -38,7 +38,7 @@ from graftm.graftm_package import GraftMPackageVersion2, GraftMPackage
 from graftm.sequence_io import Sequence
 from graftm.external_program_suite import ExternalProgramSuite
 
-prerequisites = ExternalProgramSuite(['taxit', 'FastTreeMP', 'seqmagick', 'hmmalign', 'mafft'])
+prerequisites = ExternalProgramSuite(['taxit', 'FastTreeMP', 'hmmalign', 'mafft'])
 path_to_script = os.path.join(os.path.dirname(os.path.realpath(__file__)),'..','bin','graftM')
 path_to_data = os.path.join(os.path.dirname(os.path.realpath(__file__)),'data')
 

--- a/test/test_update.py
+++ b/test/test_update.py
@@ -36,7 +36,7 @@ from graftm.external_program_suite import ExternalProgramSuite
 from graftm.update import Update
 from graftm.sequence_io import SequenceIO
 
-prerequisites = ExternalProgramSuite(['taxit', 'FastTreeMP', 'seqmagick', 'hmmalign', 'mafft'])
+prerequisites = ExternalProgramSuite(['taxit', 'FastTreeMP', 'hmmalign', 'mafft'])
 path_to_script = os.path.join(os.path.dirname(os.path.realpath(__file__)),'..','bin','graftM')
 path_to_data = os.path.join(os.path.dirname(os.path.realpath(__file__)),'data')
 


### PR DESCRIPTION
Since seqmagick has become python-3, thought we should remove it. Easy enough since it's a thin wrapper around Bio::SeqIO. Also should make graftm slightly faster as fewer subprocess python instances need to be started.

Apologies for the whitespace noise. I'm reasonably confident here as all the changes are quite local within functions, and the tests all pass.