### PR TITLE
graft: Use specified --input_sequence_type.

### DIFF
--- a/bin/graftM
+++ b/bin/graftM
@@ -39,6 +39,7 @@ import graftm
 from graftm.run import Run
 from graftm.housekeeping import HouseKeeping
 from graftm.archive import ArchiveDefaultOptions
+from graftm.unpack_sequences import UnpackRawReads
 
 class CustomHelpFormatter(argparse.HelpFormatter):
     def _split_lines(self, text, width):
@@ -155,7 +156,7 @@ Using an assembly to create a "expand_search" database:
     input_options.add_argument('--graftm_package', metavar='reference_package', help='Path to the gene specific GraftM package (gpkg).')
     running_options = graft_parser.add_argument_group('running options')
     running_options.add_argument('--threads', type=int, metavar='threads', help='The number of threads to be used when running hmmsearch and pplacer', default=5)
-    running_options.add_argument('--input_sequence_type', help='Specify whether the input sequence is "nucleotide" or "aminoacid" sequence data', choices = ['aminoacid', 'nucleotide'],  default=argparse.SUPPRESS)
+    running_options.add_argument('--input_sequence_type', help='Specify whether the input sequence is "nucleotide" or "aminoacid" sequence data [default: guess]', choices = [UnpackRawReads.PROTEIN_SEQUENCE_TYPE, UnpackRawReads.NUCLEOTIDE_SEQUENCE_TYPE],  default=None)
     running_options.add_argument('--filter_minimum', type=int, metavar='filter_minimum', help='Minimum number of positions that must be aligned for a sequence to be placed in the phylogenetic tree (default: %sbp for nucleotide packages, %s aa for protein packages)' %
                                  (Run.MIN_ALIGNED_FILTER_FOR_NUCLEOTIDE_PACKAGES, Run.MIN_ALIGNED_FILTER_FOR_AMINO_ACID_PACKAGES))
 

--- a/graftm/run.py
+++ b/graftm/run.py
@@ -326,7 +326,7 @@ class Run:
         logging.debug('Working with %i file(s)' % len(self.sequence_pair_list))
         for pair in self.sequence_pair_list:
             # Guess the sequence file type, if not already specified to GraftM
-            unpack = UnpackRawReads(pair[0])
+            unpack = UnpackRawReads(pair[0], self.args.input_sequence_type)
 
             # Set the basename, and make an entry to the summary table.
             base = unpack.basename()
@@ -340,7 +340,7 @@ class Run:
 
             # for each of the paired end read files
             for read_file in pair:
-                unpack = UnpackRawReads(read_file)
+                unpack = UnpackRawReads(read_file, self.args.input_sequence_type)
                 if not os.path.isfile(read_file): # Check file exists
                     logging.info('%s does not exist! Skipping this file..' % read_file)
                     continue

--- a/graftm/unpack_sequences.py
+++ b/graftm/unpack_sequences.py
@@ -7,37 +7,48 @@ from string import lower
 
 class UnpackRawReads:
     class UnexpectedFileFormatException(Exception): pass
-    
+
     FORMAT_FASTA    = "FORMAT_FASTA"
     FORMAT_FASTQ    = "FORMAT_FASTQ"
     FORMAT_FASTQ_GZ = "FORMAT_FASTQ_GZ"
     FORMAT_FASTA_GZ = "FORMAT_FASTA_GZ"
-    
+
     PROTEIN_SEQUENCE_TYPE = 'aminoacid'
     NUCLEOTIDE_SEQUENCE_TYPE = 'nucleotide'
-    
+
     _EXTENSION_TO_FILE_TYPE = {'.fa': FORMAT_FASTA,
                                '.faa': FORMAT_FASTA,
                                '.fna': FORMAT_FASTA,
                                '.fasta': FORMAT_FASTA,
-                               
+
                                '.fq': FORMAT_FASTQ,
                                '.fastq': FORMAT_FASTQ,
-                               
+
                                '.fq.gz': FORMAT_FASTQ_GZ,
                                '.fastq.gz': FORMAT_FASTQ_GZ,
-                               
+
                                '.fa.gz': FORMAT_FASTA_GZ,
                                '.faa.gz': FORMAT_FASTA_GZ,
                                '.fna.gz': FORMAT_FASTA_GZ,
                                '.fasta.gz': FORMAT_FASTA_GZ,
                                }
-    
-    def __init__(self, read_file):
-        self.read_file   = read_file
-    
+
+    def __init__(self, read_file, known_sequence_type=None):
+        '''New object from a read file.
+
+        read_file: str
+            path to input reads
+        sequence_type: str:
+            PROTEIN_SEQUENCE_TYPE, NUCLEOTIDE_SEQUENCE_TYPE or None
+            Whether input is nucleotide, amino acid, or should be guessed by
+        peeking at the input sequence file.
+
+        '''
+        self.read_file = read_file
+        self.known_sequence_type = known_sequence_type
+
     def _guess_sequence_type_from_string(self, seq):
-        '''Return 'protein' if there is >10% amino acid residues in the 
+        '''Return 'protein' if there is >10% amino acid residues in the
         (string) seq parameter, else 'nucleotide'. Raise Exception if a
         non-standard character is encountered'''
         # Define expected residues for each sequence type
@@ -45,7 +56,7 @@ class UnpackRawReads:
         aas = set(itertools.chain(aa_chars, [lower(a) for a in aa_chars]))
         na_chars = ['A', 'T', 'G', 'C', 'N', 'U']
         nas = set(itertools.chain(na_chars, [lower(a) for a in na_chars]))
-        
+
         num_nucleotide = 0
         num_protein = 0
         count = 0
@@ -62,18 +73,18 @@ class UnpackRawReads:
             return self.PROTEIN_SEQUENCE_TYPE
         else:
             return self.NUCLEOTIDE_SEQUENCE_TYPE
-    
+
     def sequence_type(self):
         '''Guess the type of input sequence provided to graftM (i.e. nucleotide
         or amino acid) and return'''
-        if hasattr(self, "type"):
-            return self.type
+        if self.known_sequence_type is not None:
+            return self.known_sequence_type
         else:
-            # If its Gzipped and fastq make a small sample of the sequence to be 
+            # If its Gzipped and fastq make a small sample of the sequence to be
             # read
             cmd='%s | head -n 2' % (self.command_line())
             first_seq = subprocess.check_output(
-                                                cmd, 
+                                                cmd,
                                                 shell=True,
                                                 preexec_fn=lambda:signal(SIGPIPE, SIG_DFL)
                                                 )
@@ -83,27 +94,27 @@ class UnpackRawReads:
             return self.type
 
     def guess_sequence_input_file_format(self, sequence_file_path):
-        '''Given a sequence file, guess the format and return. Raise an 
+        '''Given a sequence file, guess the format and return. Raise an
         exception if it cannot be guessed'''
         return self._EXTENSION_TO_FILE_TYPE[self._get_extension(sequence_file_path)]
-    
+
     def format(self):
         return self.guess_sequence_input_file_format(self.read_file)
-    
+
     def is_zcattable(self):
         return self.guess_sequence_input_file_format(self.read_file) in \
             (self.FORMAT_FASTA_GZ, self.FORMAT_FASTQ_GZ)
-            
+
     def basename(self):
-        '''Return the name of the file with the '.fasta' or 'fq.gz' etc 
+        '''Return the name of the file with the '.fasta' or 'fq.gz' etc
         removed'''
         return os.path.basename(self.read_file)[:-len(self._get_extension(self.read_file))]
-        
+
     def _get_extension(self, sequence_file_path):
         for ext in self._EXTENSION_TO_FILE_TYPE.keys():
             if sequence_file_path.endswith(ext): return ext
         raise self.UnexpectedFileFormatException("Unable to guess file format of sequence file: %s" % sequence_file_path)
-    
+
     def command_line(self):
         '''Return a string to open read files with'''
         file_format=self.guess_sequence_input_file_format(self.read_file)
@@ -117,4 +128,4 @@ class UnpackRawReads:
         elif file_format == self.FORMAT_FASTQ:
             cmd="""awk '{print ">" substr($0,2);getline;print;getline;getline}' %s""" % (self.read_file)
         logging.debug("raw read unpacking command chunk: %s" % cmd)
-        return cmd 
+        return cmd


### PR DESCRIPTION
I came across a bug - the input sequence type was being ignored as a parameter. Most of the time the guessing works fine so it wasn't an issue. Fixing that also means things are slightly faster when it is specified (1% on my laptop), which is a little nice.