### PR TITLE
Create no tree

### DIFF
--- a/graftm.yml
+++ b/graftm.yml
@@ -1,0 +1,27 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - python>3.6
+  - orfm>=0.2.0
+  - hmmer=3.2.1
+  - mfqe>=0.5.0
+  - pplacer
+  - krona>=2.4
+  - mafft>=7.22
+  - diamond>=0.9
+  - fasttree
+  - biopython>=1.64
+  - biom-format>=2.1.4
+  - extern
+  - taxtastic>=0.5.4
+  - tempdir
+  - backports.tempfile
+  - dendropy>= 4.1.0
+  - nose
+  - sqlite
+  - curl
+  - pyyaml
+  - fastalite
+  - jinja2

--- a/test/test_create.py
+++ b/test/test_create.py
@@ -310,6 +310,19 @@ r6\td__Archaea;p__Euryarchaeota;c__Methanomicrobia;o__Halobacteriales;f__Halobac
                 self.assertEqual(21, len(tree.leaf_nodes()))
 
 
+    def test_create_no_tree(self):
+        with tempdir.TempDir() as tmp:
+            gpkg = tmp+".gpkg"
+            Create(prerequisites).main(sequences=os.path.join(path_to_data,'create','homologs.trimmed.unaligned.faa'),
+                          taxonomy=os.path.join(path_to_data,'create','homologs.tax2tree.rerooted.decorated.tree-consensus-strings'),
+                          prefix=gpkg,
+                          no_tree = True,
+                          threads=5)
+            pkg = GraftMPackage.acquire(gpkg)
+            with self.assertRaises(KeyError) as context:
+                pkg.reference_package_tree_path()
+
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.ERROR)
     unittest.main()


### PR DESCRIPTION
Implement graftM create --no-tree, tested by test_create.py/test_create_no_tree
Also implemented _taxit_create_no_tree in create.py to generate a refpkg from taxit without a tree.

Also includes conda environment file for testing. All the tests pass in this environment except three diamond tests (test_diamond.py/test_blastp and test_basename, and test_graft.py/test_diamond_translate).