### PR TITLE
fix create no-tree flag

### DIFF
--- a/bin/graftM
+++ b/bin/graftM
@@ -261,7 +261,7 @@ that are redundant at the 3rd rank (from left to right in the taxonomy file) fro
     create_lesser_options.add_argument('--min_aligned_percent', type=int, metavar='percent', help='Remove sequences from the alignment which do not cover at least this percentage of the HMM', default=30)
     create_lesser_options.add_argument('--output', metavar='PATH', help='Name of output GraftM package.')
     create_lesser_options.add_argument('--tree_log', help='A log file for the tree.')
-    create_lesser_options.add_argument('--no-tree', '--no_tree', help='Disable tree creation.')
+    create_lesser_options.add_argument('--no-tree', '--no_tree', action="store_true", help='Disable tree creation.')
     create_lesser_options.add_argument('--taxtastic_taxonomy', help='A taxtastic format taxonomy file. (default: use taxonomy from --taxonomy)')
     create_lesser_options.add_argument('--taxtastic_seqinfo', help='A taxtastic format seqinfo file. (default: use taxonomy from --taxonomy)')
     create_lesser_options.add_argument('--force', action="store_true", help='Overwrite output gpkg directory if it exists.', default=False)


### PR DESCRIPTION
Switch to store as true rather than wanting an argument.
This is what I get for not unit testing the cli.

With this change, running graftM create --no-tree from singlem works as expected.