### PR TITLE
account for no hits by non-decoy diamond db

### DIFF
--- a/graftm/decoy_filter.py
+++ b/graftm/decoy_filter.py
@@ -76,8 +76,10 @@ class DecoyFilter:
                          " sequences which hit the decoy sequences better"
                          " than the non-decoy sequences" %\
                          (num_before_decoy_removal-len(seq_ids_and_bitscores)))
-            if len(seq_ids_and_bitscores) == 0:
-                return False
+
+        # Either all non-decoy hits were removed as decoys or no non-decoy hits were found
+        if len(seq_ids_and_bitscores) == 0:
+            return False
 
         # Extract the found sequences into the output file
         logging.debug("Extracting query sequences")

--- a/graftm/decoy_filter.py
+++ b/graftm/decoy_filter.py
@@ -77,7 +77,7 @@ class DecoyFilter:
                          " than the non-decoy sequences" %\
                          (num_before_decoy_removal-len(seq_ids_and_bitscores)))
 
-        # Either all non-decoy hits were removed as decoys or no non-decoy hits were found
+        # Either all candidate hits were removed as decoys or no candidate hits were found
         if len(seq_ids_and_bitscores) == 0:
             return False
 


### PR DESCRIPTION
Move length of seq_ids_and_bitscores check outside of decoy database section to account for using a non-decoy diamond database for filtering (using `--search_method hmmsearch+diamond`) without using decoy database.